### PR TITLE
Add read-only functions and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ A decentralized e-commerce marketplace built on Stacks blockchain.
 - Review system for buyers and sellers
 - Escrow system for secure transactions
 - Dispute resolution mechanism
+- Read-only functions to query product and purchase details
 
 ## Getting Started
 [Instructions for setting up and running the project]
 
 ## Contract Documentation
-[Detailed documentation of contract functions and usage]
+### Read-only Functions
+- `get-product`: Get details of a specific product by ID
+- `get-purchase`: Get details of a purchase by product ID
+
+### Public Functions
+- `list-product`: List a new product for sale
+- `purchase-product`: Purchase a listed product
+- `confirm-delivery`: Confirm receipt of purchased product
+
+[Additional contract documentation]

--- a/contracts/aether-store.clar
+++ b/contracts/aether-store.clar
@@ -5,6 +5,7 @@
 (define-constant err-item-not-found (err u102))
 (define-constant err-already-purchased (err u103))
 (define-constant err-not-seller (err u104))
+(define-constant err-not-buyer (err u105))
 
 ;; Define data structures
 (define-map products
@@ -53,6 +54,16 @@
   )
 )
 
+;; Get product details
+(define-read-only (get-product (product-id uint))
+  (map-get? products { product-id: product-id })
+)
+
+;; Get purchase details
+(define-read-only (get-purchase (product-id uint))
+  (map-get? purchases { product-id: product-id })
+)
+
 ;; Purchase a product
 (define-public (purchase-product (product-id uint))
   (let ((product (unwrap! (map-get? products { product-id: product-id }) err-item-not-found)))
@@ -93,7 +104,7 @@
         )
         (ok true)
       )
-      (err u105)
+      err-not-buyer
     )
   )
 )

--- a/tests/aether-store_test.ts
+++ b/tests/aether-store_test.ts
@@ -24,8 +24,24 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name: "Ensure can purchase a product",
+  name: "Ensure can get product details",
   async fn(chain: Chain, accounts: Map<string, Account>) {
-    // Test implementation
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall("aether-store", "list-product", 
+        [types.ascii("Test Product"), types.utf8("Description"), types.uint(1000)],
+        wallet_1.address
+      )
+    ]);
+    
+    let getProductResult = chain.callReadOnlyFn(
+      "aether-store",
+      "get-product",
+      [types.uint(0)],
+      wallet_1.address
+    );
+    
+    assertEquals(getProductResult.result.expectSome().data.name, "Test Product");
   },
 });


### PR DESCRIPTION
This PR adds new read-only functions to the AetherStore contract and improves error handling:

### Changes:
1. Added `get-product` read-only function to query product details
2. Added `get-purchase` read-only function to query purchase details
3. Named error constant for not-buyer error (u105)
4. Added test for get-product function
5. Updated documentation to reflect new functions

### Benefits:
- Improved contract accessibility with read-only functions
- Better error handling with named constants
- Enhanced testing coverage
- Updated documentation for easier integration

### Testing:
- Added new test case for get-product function
- Existing tests pass
- Manually verified read-only functions work as expected

No breaking changes were introduced.